### PR TITLE
Propagate schema on empty result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-engine-datafusion"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamu-engine-datafusion"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Kamu Data Inc. <info@kamu.dev>"]
 license-file = "LICENSE.txt"
 edition = "2021"

--- a/tests/tests/test_transform.rs
+++ b/tests/tests/test_transform.rs
@@ -299,8 +299,6 @@ async fn test_query_common(opts: TestQueryCommonOpts) {
     if let Some(expected_data) = expected_data {
         let actual_data = read_data_pretty(&new_data_path).await;
         assert_eq!(expected_data.trim(), actual_data);
-    } else {
-        assert!(!new_data_path.exists());
     }
 
     if let Some(expected_schema) = opts.expected_schema {


### PR DESCRIPTION
Previously engine would clean up the Parquet file if no records were written, however this means that a dataset that is legitimately always empty and produces watermarks will never have the schema defined, making it impossible to use in pipelines.

This change preserves empty Parquet files and allows kamu to extract output schema from them.